### PR TITLE
Convert component root element data attributes to a JavaScript object

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -44,6 +44,8 @@ export default class Button extends AbstractComponent {
   // this should match the 'data-component' attribute value on the HTML element
   static displayName:string = 'button';
 
+  private btn:HTMLElement;
+
   // the html element from the handlebars template is passed
   constructor(el:HTMLElement) {
     super(el);
@@ -61,6 +63,45 @@ export default class Button extends AbstractComponent {
   public dispose() {
     this.btn.removeEventListener('click', this.handleButtonClick);
     this.btn = null;
+
+    super.dispose();
+  }
+}
+```
+
+Component data attributes are available in a component and can be accessed using data object on the component.
+The data attributes are stored as camelCased keys in the data object, without the data- prefix. So 
+attribute `data-slide-interval` can be referenced within a component using `this.data.slideInterval`.
+ 
+The component data object values are stored as strings. Validating and parsing this data is up to the component author.
+
+An example of using a data attribute
+```
+<script src="./Carousel.ts"></script>
+<div data-component="carousel" data-slide-interval="2000">...</div>
+```
+
+```
+import AbstractComponent from "app/component/AbstractComponent";
+
+export default class Carousel extends AbstractComponent {
+  static displayName:string = 'carousel';
+
+  private slideInterval:number;
+
+  constructor(el:HTMLElement) {
+    super(el);
+
+    const interval = (this.data.slideInterval && parseInt(this.data.slideInterval, 10)) || 5000;
+
+    this.slideInterval = setInterval(() => {
+      // Some code to slide your carousel
+    }, interval);
+  }
+
+  public dispose() {
+    clearInterval(this.slideInterval);
+    this.slideInterval = null;
 
     super.dispose();
   }

--- a/src/app/component/AbstractComponent.ts
+++ b/src/app/component/AbstractComponent.ts
@@ -1,7 +1,23 @@
+import camelCase from 'lodash/camelCase';
+
 export default class AbstractComponent {
-  constructor(public element: HTMLElement) {}
+  protected data: { [key: string]: string };
+
+  constructor(public element: HTMLElement) {
+    this.data = Object.values(element.attributes)
+      .map(attribute => ({ name: attribute.nodeName, value: attribute.value }))
+      .filter(node => node.name.includes('data-'))
+      .reduce(
+        (accumulator, node) => ({
+          ...accumulator,
+          [camelCase(node.name.replace(/^data-/, ''))]: node.value,
+        }),
+        {},
+      );
+  }
 
   dispose() {
     this.element = null;
+    this.data = null;
   }
 }

--- a/src/app/component/AbstractComponent.ts
+++ b/src/app/component/AbstractComponent.ts
@@ -5,7 +5,7 @@ export default class AbstractComponent {
 
   constructor(public element: HTMLElement) {
     this.data = Object.values(element.attributes)
-      .filter(attribute => attribute.nodeName.includes('data-'))
+      .filter(attribute => attribute.nodeName.startsWith('data-'))
       .reduce(
         (accumulator, attribute) => ({
           ...accumulator,

--- a/src/app/component/AbstractComponent.ts
+++ b/src/app/component/AbstractComponent.ts
@@ -5,12 +5,11 @@ export default class AbstractComponent {
 
   constructor(public element: HTMLElement) {
     this.data = Object.values(element.attributes)
-      .map(attribute => ({ name: attribute.nodeName, value: attribute.value }))
-      .filter(node => node.name.includes('data-'))
+      .filter(attribute => attribute.nodeName.includes('data-'))
       .reduce(
-        (accumulator, node) => ({
+        (accumulator, attribute) => ({
           ...accumulator,
-          [camelCase(node.name.replace(/^data-/, ''))]: node.value,
+          [camelCase(attribute.nodeName.replace(/^data-/, ''))]: attribute.value,
         }),
         {},
       );


### PR DESCRIPTION
When the root level element of a component contains a data attributes it will become available within a component.

For example having  `<div data-component="paragraph" data-sort-type="ascending">...</div>` will convert to a object

```
{
   component: 'paragraph',
   sortType: 'ascending',
}
```

which is available in the component as `this.data`