### PR TITLE
Add the icon component for rendering svg icons

### DIFF
--- a/src/app/component/general/icon/Icon.ts
+++ b/src/app/component/general/icon/Icon.ts
@@ -1,0 +1,24 @@
+import AbstractComponent from 'app/component/AbstractComponent';
+
+declare function require(name: string): string;
+
+/**
+ * Note: Please be aware that all svg icons in the folder "app/svg/*.svg"
+ * will be included in your final bundle.js, so leave out all unused svg
+ * icons to keep your bundle as small as possible!
+ *
+ * Example usage:
+ *
+ * ```html
+ * {{> general/icon name="logo-gap" }}
+ * ```
+ */
+export default class Icon extends AbstractComponent {
+  static displayName: string = 'icon';
+
+  constructor(el: HTMLElement) {
+    super(el);
+
+    el.innerHTML = require(`app/svg/${el.getAttribute('data-icon')}.svg`);
+  }
+}

--- a/src/app/component/general/icon/Icon.ts
+++ b/src/app/component/general/icon/Icon.ts
@@ -19,6 +19,6 @@ export default class Icon extends AbstractComponent {
   constructor(el: HTMLElement) {
     super(el);
 
-    el.innerHTML = require(`app/svg/${el.getAttribute('data-icon')}.svg`);
+    el.innerHTML = require(`app/svg/icon/${this.data.icon}.svg`);
   }
 }

--- a/src/app/component/general/icon/icon.hbs
+++ b/src/app/component/general/icon/icon.hbs
@@ -1,0 +1,4 @@
+<link rel="stylesheet" href="./icon.scss">
+<script src="./Icon.ts"></script>
+
+<span data-component="icon" data-icon="{{name}}"></span>

--- a/src/app/component/general/icon/icon.scss
+++ b/src/app/component/general/icon/icon.scss
@@ -1,0 +1,10 @@
+/* stylelint-disable-next-line block-no-empty */
+[data-component='icon'] {
+  display: inline-block;
+  vertical-align: middle;
+
+  svg {
+    @include size(100%);
+    display: block;
+  }
+}

--- a/src/app/component/general/icon/preset.js
+++ b/src/app/component/general/icon/preset.js
@@ -1,0 +1,13 @@
+/* eslint-disable max-len */
+import { storiesOf } from 'storybook/utils/utils';
+
+storiesOf('icon', require('./icon.hbs')).add(
+  'default',
+  'This component is used to render out svg icons.',
+  `<hbs>
+			{{> icon @root name=name}}
+		</hbs>`,
+  {
+    name: 'svg-name',
+  },
+);

--- a/src/app/data/model.ts
+++ b/src/app/data/model.ts
@@ -1,9 +1,9 @@
 // import ko from 'knockout';
 
 class Model {
-	// global model to share global state
-	// you can use knockout observables to dispatch/listen to changes
-	// or extend EventDispatcher to listen for generic events
+  // global model to share global state
+  // you can use knockout observables to dispatch/listen to changes
+  // or extend EventDispatcher to listen for generic events
 }
 
 export default new Model();


### PR DESCRIPTION
The`svg-inline-loader` and the `svgo-loader` are already included but there is no plug and play icon component.  

We use SVG icons all the time so to make this easier I included the same icon component as used in the vue-skeleton.