### PR TITLE
Add default meta tags and title to webpack index.html

### DIFF
--- a/build-tools/config/webpack/index.html
+++ b/build-tools/config/webpack/index.html
@@ -1,6 +1,10 @@
 <!-- webpack-dev-server template -->
 <html>
 <head>
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
+  <title>Muban</title>
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
Add the default meta tags and title to index.html. The viewport meta-tag was missing causing safari to scale the website to fit the screen-size