### PR TITLE
Add Symbol polyfill for IE11 only on dev-server.

### DIFF
--- a/src/app/bootstrap.dev.ts
+++ b/src/app/bootstrap.dev.ts
@@ -6,6 +6,8 @@ import 'modernizr';
 // tslint:disable import-name
 import Handlebars from 'handlebars/runtime';
 import { bootstrap } from 'muban-core/lib/dev';
+import symbol from 'core-js/es6/symbol';
+symbol;
 
 declare var require: any;
 declare var module: any;


### PR DESCRIPTION
Add Symbol polyfill for IE11 only on dev-server. Symbol is used via joi-browser in extract-html-data module