### PR TITLE
Fix and update the seng generator flow for pages

### DIFF
--- a/build-tools/template/page/.senggenerator
+++ b/build-tools/template/page/.senggenerator
@@ -2,14 +2,9 @@
   "destination": "./src/data",
   "variables": [{
     "name": "blocks",
-    "type": "confirm",
-    "message": "Do you want to add blocks?",
-    "isBoolean": true,
-    "default": false
-  },{
-    "name": "blocks",
-    "message": "Add a list of comma separated blocks",
+   	"type": "input",
+    "message": "Add a list of comma separated blocks (optional)",
     "isArray": true,
-    "default": false
+    "default": []
   }]
 }


### PR DESCRIPTION
In the old situation the user was confronted with a confirm (y/N) where he could choose wether or not it wanted to add blocks to the page. Regardless of his choice it would get the option. Now the confirm has been removed and the option is given to add them directly (or not).