### PR TITLE
Remove year of copyright in footer

### DIFF
--- a/src/app/component/block/footer/footer.hbs
+++ b/src/app/component/block/footer/footer.hbs
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="./footer.scss">
 
 <div data-component="footer">
-  <p>© 2017 MediaMonks B.V.</p>
+  <p>© MediaMonks B.V.</p>
 </div>


### PR DESCRIPTION
I removed the reference to 2017 from the copyright statement in the footer