### PR TITLE
Add "skeleton" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "muban",
   "version": "3.0.0",
+  "skeleton": {
+    "name": "muban",
+    "version": "3.0.0"
+  },
   "description": "",
   "scripts": {
     "dev": "webpack-dev-server --config build-tools/config/webpack/webpack.conf.dev.js",


### PR DESCRIPTION
Create a "skeleton" field that mirrors the "name" and "version" properties.

The reasoning behind this: when you create your own project, you should be able to change the "version" and "name" field in `package.json` to reflect your project rather than `muban`. If we do that however, we lose information about which skeleton version the project was originally started with.