### PR TITLE
Update the cleanup script

### DIFF
--- a/build-tools/script/cleanup.js
+++ b/build-tools/script/cleanup.js
@@ -36,7 +36,9 @@ function clean() {
     path.join(projectRoot, 'src/app/svg/icon/*.svg'),
 
     // pages
-    path.join(projectRoot, 'src/data/*'),
+    path.join(projectRoot, 'src/data/home.yaml'),
+    path.join(projectRoot, 'src/data/about.yaml'),
+    path.join(projectRoot, 'src/data/test.js'),
 
     // blocks
     path.join(projectRoot, 'src/app/component/block/paragraph'),


### PR DESCRIPTION
Currently the cleanup script removes everything in the data folder (including the `_variables.yaml`) and this causes the application to break. 

I've updated the cleanup script to only remove the boilerplate specific data files, this fixes #86.