### PR TITLE
Override singleQuote option for SCSS files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -10,6 +10,12 @@
       "options": {
         "printWidth": 999999
       }
+    },
+    {
+      "files": "*.scss",
+      "options": {
+        "singleQuote": false
+      }
     }
   ]
 }

--- a/src/app/component/block/footer/footer.scss
+++ b/src/app/component/block/footer/footer.scss
@@ -1,4 +1,4 @@
-[data-component='footer'] {
+[data-component="footer"] {
   border-top: 1px solid #ddd;
   background-color: #eee;
   height: 50px;

--- a/src/app/component/block/header/header.scss
+++ b/src/app/component/block/header/header.scss
@@ -1,4 +1,4 @@
-[data-component='header'] {
+[data-component="header"] {
   border-bottom: 1px solid #ddd;
   background-color: #eee;
 

--- a/src/app/component/block/paragraph/paragraph.scss
+++ b/src/app/component/block/paragraph/paragraph.scss
@@ -1,4 +1,4 @@
-[data-component='paragraph'] {
+[data-component="paragraph"] {
   margin-bottom: 30px;
 
   .hidden {

--- a/src/app/component/block/two-col/two-col.scss
+++ b/src/app/component/block/two-col/two-col.scss
@@ -1,4 +1,4 @@
-[data-component='two-col'] {
+[data-component="two-col"] {
   margin-bottom: 30px;
   font-size: 0;
 
@@ -20,12 +20,12 @@
 
     &.col-left {
       img {
-        background-image: url('./image/demo.jpg');
+        background-image: url("./image/demo.jpg");
       }
     }
     &.col-right {
       img {
-        background-image: url('./image/demo.png');
+        background-image: url("./image/demo.png");
       }
     }
   }

--- a/src/app/component/general/button/button.scss
+++ b/src/app/component/general/button/button.scss
@@ -1,4 +1,4 @@
-[data-component='button'] {
+[data-component="button"] {
   border-radius: 2px;
   border: 1px solid #ddd;
   background-color: #eee;

--- a/src/app/component/layout/app/app.scss
+++ b/src/app/component/layout/app/app.scss
@@ -1,1 +1,1 @@
-@import '../../../style/main';
+@import "../../../style/main";

--- a/src/app/component/layout/index/index.scss
+++ b/src/app/component/layout/index/index.scss
@@ -30,7 +30,7 @@ $colorQA: #1e90ff;
 $colorFeedback: #dc4832;
 $colorDone: #0eb415;
 
-[data-component='index-root'] {
+[data-component="index-root"] {
   height: 100%;
 
   * {
@@ -234,5 +234,5 @@ $colorDone: #0eb415;
     }
   }
 
-  @import 'index-footer';
+  @import "index-footer";
 }

--- a/src/app/style/_global.scss
+++ b/src/app/style/_global.scss
@@ -6,4 +6,4 @@
  * This file is used next to "seng-scss" which is imported globally as well and contain the default mixins/vars/functions
  */
 
-@import 'util/variables';
+@import "util/variables";

--- a/src/app/style/main.scss
+++ b/src/app/style/main.scss
@@ -1,10 +1,10 @@
-@import '~normalize.css';
-@import '~seng-scss';
+@import "~normalize.css";
+@import "~seng-scss";
 
 /* Globally available project specific mixins, functions and variables */
-@import 'global';
+@import "global";
 
-@import 'type/font';
-@import 'type/type';
+@import "type/font";
+@import "type/type";
 
 // Generic stuff

--- a/src/app/style/util/_variables.scss
+++ b/src/app/style/util/_variables.scss
@@ -1,5 +1,5 @@
 // Correctly set `seng-scss` assetPath
-$pathAsset: '~app';
+$pathAsset: "~app";
 
 // Fonts
 $baseFont: Arial, sans-serif;
@@ -10,4 +10,4 @@ $zLayout: default;
 // Colors
 $colorPrimaryTheme: #ff6e3f;
 
-@import '../../data/shared-variable/media-queries.json';
+@import "../../data/shared-variable/media-queries.json";


### PR DESCRIPTION
Yesterday I was having some issues with Prettier breaking styles on pre-commit linting.

The project I'm working on needs to support RTL so styles have a lot of `[dir=rtl]` selectors that Prettier was auto formatting to `[dir='rtl']` and breaking them.

Supported format is either `[dir=rtl]` or `[dir="rtl"]` so overriding this setting for styling files seems to be a nice solution.