### PR TITLE
Enable tslint rule member-access

### DIFF
--- a/.tslintrc.js
+++ b/.tslintrc.js
@@ -13,5 +13,6 @@ module.exports = {
     'no-increment-decrement': false,
     'strict-boolean-expressions': false,
     'import-name': false,
+    'member-access': true,
   },
 };

--- a/src/app/component/block/paragraph/Paragraph.ts
+++ b/src/app/component/block/paragraph/Paragraph.ts
@@ -3,7 +3,7 @@ import Icon from '../../general/icon/Icon';
 import AbstractBlock from '../AbstractBlock';
 
 export default class Paragraph extends AbstractBlock {
-  static displayName: string = 'paragraph';
+  public static readonly displayName: string = 'paragraph';
 
   private btn: HTMLButtonElement | null;
   private btnLabel: HTMLSpanElement | undefined | null;

--- a/src/app/component/general/icon/Icon.ts
+++ b/src/app/component/general/icon/Icon.ts
@@ -16,7 +16,7 @@ const svgContext = require.context('app/svg/icon/?inline', false, /\.svg/);
  * ```
  */
 export default class Icon extends AbstractComponent {
-  static displayName: string = 'icon';
+  public static readonly displayName: string = 'icon';
 
   constructor(el: HTMLElement) {
     super(el);

--- a/src/app/component/layout/app/App.ts
+++ b/src/app/component/layout/app/App.ts
@@ -1,7 +1,7 @@
 import AbstractComponent from '../../AbstractComponent';
 
 export default class App extends AbstractComponent {
-  static displayName: string = 'app-root';
+  public static readonly displayName: string = 'app-root';
 
   constructor(element: HTMLElement) {
     super(element);

--- a/src/app/component/layout/index/Index.ts
+++ b/src/app/component/layout/index/Index.ts
@@ -1,7 +1,7 @@
 import AbstractComponent from '../../AbstractComponent';
 
 export default class App extends AbstractComponent {
-  static displayName: string = 'index-root';
+  public static readonly displayName: string = 'index-root';
 
   constructor(element: HTMLElement) {
     super(element);
@@ -31,7 +31,7 @@ export default class App extends AbstractComponent {
     // for generic app logic
   }
 
-  updateBlocksButton() {
+  private updateBlocksButton() {
     const pages = this.getElements('.page');
     if (pages.some(page => page.classList.contains('show-blocks'))) {
       this.getElement('.toggle-blocks').innerText = 'hide blocks';


### PR DESCRIPTION
We should make it mandatory to always add an explicit member access declaration.

I see a lot of developers leave out the access declaration, which makes something `public` by default. I think you should only set something to public when it has to be public. Otherwise it should be `private` (or `protected` when needed). By enabling this rule we force developers to think about the member accessibility.

See https://palantir.github.io/tslint/rules/member-access/