### PR TITLE
Update generator templates

### DIFF
--- a/build-tools/generator-template/block/{name_sc}/{name_pc}.ts
+++ b/build-tools/generator-template/block/{name_sc}/{name_pc}.ts
@@ -1,7 +1,7 @@
 import AbstractBlock from '../AbstractBlock';
 
 export default class {{name_pc}} extends AbstractBlock {
-  static displayName:string = '{{name_sc}}';
+  public static readonly displayName:string = '{{name_sc}}';
 
   constructor(el:HTMLElement) {
     super(el);

--- a/build-tools/generator-template/block/{name_sc}/{name_sc}.scss
+++ b/build-tools/generator-template/block/{name_sc}/{name_sc}.scss
@@ -1,4 +1,3 @@
-/* stylelint-disable-next-line block-no-empty */
 .{{name_sc}} {
 
 }

--- a/build-tools/generator-template/component/{name_sc}/{name_sc}.scss
+++ b/build-tools/generator-template/component/{name_sc}/{name_sc}.scss
@@ -1,4 +1,3 @@
-/* stylelint-disable-next-line block-no-empty */
 .{{name_sc}} {
 
 }

--- a/build-tools/generator-template/smart-component/{name_sc}/{name_pc}.ts
+++ b/build-tools/generator-template/smart-component/{name_sc}/{name_pc}.ts
@@ -1,7 +1,7 @@
 import AbstractComponent from '../AbstractComponent';
 
 export default class {{name_pc}} extends AbstractComponent {
-  static displayName:string = '{{name_sc}}';
+  public static readonly displayName:string = '{{name_sc}}';
 
   constructor(el:HTMLElement) {
     super(el);

--- a/build-tools/generator-template/smart-component/{name_sc}/{name_sc}.scss
+++ b/build-tools/generator-template/smart-component/{name_sc}/{name_sc}.scss
@@ -1,4 +1,3 @@
-/* stylelint-disable-next-line block-no-empty */
 .{{name_sc}} {
 
 }


### PR DESCRIPTION
Seng Generator templates update: Add the keyword `public` and `readonly` for static displayName and remove disabling of style lint rule by default.

I think we should not disable a linting rule in every template. If we don't like this linting rule, we should disable or remove this rule in the linting settings. We added that rule for a reason, disabling this rule in all css files does not make sense.
