### PR TITLE
Rename btn to button since we should not use abbreviations

### DIFF
--- a/src/app/component/block/paragraph/Paragraph.ts
+++ b/src/app/component/block/paragraph/Paragraph.ts
@@ -5,19 +5,19 @@ import AbstractBlock from '../AbstractBlock';
 export default class Paragraph extends AbstractBlock {
   static displayName: string = 'paragraph';
 
-  private btn: HTMLButtonElement | null;
-  private btnLabel: HTMLSpanElement | undefined | null;
-  private btnIcon: HTMLElement | undefined | null;
+  private button: HTMLButtonElement | null;
+  private buttonLabel: HTMLSpanElement | undefined | null;
+  private buttonIcon: HTMLElement | undefined | null;
   private contentMore: HTMLParagraphElement | undefined;
 
   constructor(el: HTMLElement) {
     super(el);
 
-    this.btn = this.element.querySelector('button');
-    if (this.btn) {
-      this.btn.addEventListener('click', this.onButtonClick);
-      this.btnLabel = this.getElement<HTMLSpanElement>('.label', this.btn);
-      this.btnIcon = this.getElement<HTMLElement>('.icon', this.btn);
+    this.button = this.element.querySelector('button');
+    if (this.button) {
+      this.button.addEventListener('click', this.onButtonClick);
+      this.buttonLabel = this.getElement<HTMLSpanElement>('.label', this.button);
+      this.buttonIcon = this.getElement<HTMLElement>('.icon', this.button);
 
       this.contentMore = <HTMLParagraphElement>this.element.querySelector('.js-content-more');
     }
@@ -27,22 +27,22 @@ export default class Paragraph extends AbstractBlock {
     this.contentMore!.classList.toggle('hidden');
 
     if (this.contentMore!.classList.contains('hidden')) {
-      this.btnLabel!.textContent = 'read more...';
-      if (this.btnIcon) {
-        getComponentForElement<Icon>(this.btnIcon).setIcon('arrow-down');
+      this.buttonLabel!.textContent = 'read more...';
+      if (this.buttonIcon) {
+        getComponentForElement<Icon>(this.buttonIcon).setIcon('arrow-down');
       }
     } else {
-      this.btnLabel!.textContent = 'read less...';
-      if (this.btnIcon) {
-        getComponentForElement<Icon>(this.btnIcon).setIcon('arrow-up');
+      this.buttonLabel!.textContent = 'read less...';
+      if (this.buttonIcon) {
+        getComponentForElement<Icon>(this.buttonIcon).setIcon('arrow-up');
       }
     }
   };
 
   public dispose() {
-    if (this.btn) {
-      this.btn.removeEventListener('click', this.onButtonClick);
-      this.btn = null;
+    if (this.button) {
+      this.button.removeEventListener('click', this.onButtonClick);
+      this.button = null;
     }
 
     super.dispose();


### PR DESCRIPTION
We should not use abbreviations in code, so the example code should not contain any abbreviations. 