### PR TITLE
Update path to data for blocks added through generator tool

### DIFF
--- a/build-tools/generator-template/page/{name_sc}.yaml
+++ b/build-tools/generator-template/page/{name_sc}.yaml
@@ -8,9 +8,9 @@ meta:
 
 blocks:
 {{#if blocks}}
-{{#each blocks}}
+  {{#each blocks}}
   - name: "{{this}}"
-    data: "import!../app/component/block/{{this}}/data"
+    data: "import!../app/component/block/{{this}}/data/default"
 
-{{/each}}
+  {{/each}}
 {{/if}}


### PR DESCRIPTION
The link to the mock data in the generator template for pages was still pointing to the data file in the root of the block folder. It has been updated to use the default.yaml in the data folder