### PR TITLE
Enable prefixIDs svgo plugin

### DIFF
--- a/build-tools/config/webpack/webpack.partial.conf.module.js
+++ b/build-tools/config/webpack/webpack.partial.conf.module.js
@@ -228,6 +228,7 @@ module.exports = ({ config, isDevelopment, buildType, isPartials, isCode }) => w
                   { removeMetadata: true },
                   { removeComments: true },
                   { cleanupIDs: { remove: true, prefix: '' } },
+                  { prefixIds: true },
                   { convertColors: { shorthex: false } },
                 ],
               },


### PR DESCRIPTION
The cleanupIDs plugin in svgo minifies IDs, it does this for each file. The scope for inline svg elements is the document in which they're placed, this means that the id attribute value should be unique to make sure that the correct svg definition is used.

When two svg files have id attributes the values will collide, invalid HTML is generated when both files are inlined. This can cause issues in the svg files that have references to the definitions because it might reference the incorrect element.

Example with colliding IDs
![chrome_O3TsgIrtOu](https://user-images.githubusercontent.com/5376407/77526975-b5555780-6e8b-11ea-97b7-0408cb6221c7.png)

With the prefixIds plugin this is fixed because the id attribute value is prefixed with the svg filename
![chrome_qONm6vA5Wc](https://user-images.githubusercontent.com/5376407/77527068-d322bc80-6e8b-11ea-8606-e1a9f9347391.png)

Difference in output
```
<!-- Output without prefixIds -->
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
  <defs>
    <linearGradient id="a" x1=".667" x2=".417" y1=".167" y2=".75">
      <stop offset="0" stop-color="#37aee2"></stop>
      <stop offset="1" stop-color="#1e96c8"></stop>
    </linearGradient>
    <linearGradient id="b" x1=".66" x2=".851" y1=".437" y2=".802">
      <stop offset="0" stop-color="#eff7fc"></stop>
      <stop offset="1" stop-color="#fff"></stop>
    </linearGradient>
  </defs>
  <circle cx="120" cy="120" r="120" fill="url(#a)"></circle>
  <path fill="url(#b)" d="M98 175c-3.888 0-3.227-1.468-4.568-5.17L82 132.207 170 80"></path>
</svg>

<!-- Output with prefixIds  -->
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
  <defs>
    <linearGradient id="my-file_svg__a" x1=".667" x2=".417" y1=".167" y2=".75">
      <stop offset="0" stop-color="#37aee2"></stop>
      <stop offset="1" stop-color="#1e96c8"></stop>
    </linearGradient>
    <linearGradient id="my-file_svg__b" x1=".66" x2=".851" y1=".437" y2=".802">
      <stop offset="0" stop-color="#eff7fc"></stop>
      <stop offset="1" stop-color="#fff"></stop>
    </linearGradient>
  </defs>
  <circle cx="120" cy="120" r="120" fill="url(#my-file_svg__a)"></circle>
  <path fill="url(#my-file_svg__b)" d="M98 175c-3.888 0-3.227-1.468-4.568-5.17L82 132.207 170 80"></path>
</svg>
```