### PR TITLE
Fix/sync viewport meta tag

### DIFF
--- a/build-tools/templates/build-html-template-standalone.hbs
+++ b/build-tools/templates/build-html-template-standalone.hbs
@@ -8,7 +8,7 @@
   <title>Muban - {{page}}</title>
 
   <meta httpEquiv="X-UA-Compatible" content="IE=Edge,chrome=1">
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
   <link rel="icon" href="{{publicPath}}favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="{{publicPath}}asset/common.css">
   <link rel="stylesheet" href="{{publicPath}}asset/{{page}}.css">

--- a/build-tools/templates/build-html-template-standalone.hbs
+++ b/build-tools/templates/build-html-template-standalone.hbs
@@ -8,7 +8,7 @@
   <title>Muban - {{page}}</title>
 
   <meta httpEquiv="X-UA-Compatible" content="IE=Edge,chrome=1">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
   <link rel="icon" href="{{publicPath}}favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="{{publicPath}}asset/common.css">
   <link rel="stylesheet" href="{{publicPath}}asset/{{page}}.css">

--- a/build-tools/templates/build-html-template-standalone.hbs
+++ b/build-tools/templates/build-html-template-standalone.hbs
@@ -7,7 +7,7 @@
   <meta charSet="utf-8">
   <title>Muban - {{page}}</title>
 
-  <meta httpEquiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
   <link rel="icon" href="{{publicPath}}favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="{{publicPath}}asset/common.css">

--- a/build-tools/templates/build-html-template.hbs
+++ b/build-tools/templates/build-html-template.hbs
@@ -8,7 +8,7 @@
   <title>Muban - {{page}}</title>
 
   <meta httpEquiv="X-UA-Compatible" content="IE=Edge,chrome=1">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
   <link rel="icon" href="{{publicPath}}favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="{{publicPath}}asset/bundle.css">
 </head>

--- a/build-tools/templates/build-html-template.hbs
+++ b/build-tools/templates/build-html-template.hbs
@@ -8,7 +8,7 @@
   <title>Muban - {{page}}</title>
 
   <meta httpEquiv="X-UA-Compatible" content="IE=Edge,chrome=1">
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
   <link rel="icon" href="{{publicPath}}favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="{{publicPath}}asset/bundle.css">
 </head>

--- a/build-tools/templates/build-html-template.hbs
+++ b/build-tools/templates/build-html-template.hbs
@@ -7,7 +7,7 @@
   <meta charSet="utf-8">
   <title>Muban - {{page}}</title>
 
-  <meta httpEquiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
   <link rel="icon" href="{{publicPath}}favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="{{publicPath}}asset/bundle.css">

--- a/build-tools/templates/devserver-index.html
+++ b/build-tools/templates/devserver-index.html
@@ -3,8 +3,8 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no">
   <title>Muban</title>
 </head>
 <body>


### PR DESCRIPTION
The most important update is the syncing of the viewport meta tag. A built on monkapps had a different meta tag that allowed the iOS browser to zoom in on focus on a Select box.

I removed the enclosing slashes so it's consistent between templates.

Furthermore I corrected a typo in http-equiv