### PR TITLE
update seng-scss to prevent build warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "normalize.css": "^8.0.1",
     "qs": "^6.6.0",
     "seng-device-state-tracker": "^1.1.4",
-    "seng-scss": "^1.2.3",
+    "seng-scss": "^1.2.4",
     "string-replace-loader": "^2.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12468,9 +12468,9 @@ seng-generator@^0.9.0:
     user-settings "^0.1.5"
 
 seng-scss@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/seng-scss/-/seng-scss-1.2.3.tgz#ef08931ecf148a3e5fe3186fd1805539c6609cbd"
-  integrity sha512-odz9hryLjDicgDAJhJc9UrXIKzrV4zQKU/xnIKMO82/Uzkl/Sqnc2lH7ygUdP5+xejlGHsO8iun8izQZt4b/AQ==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/seng-scss/-/seng-scss-1.2.4.tgz#854665b82018eb6f9005db5003a919a6fa089752"
+  integrity sha512-7eWXNnfl3CzxaCjcQI/3lYciY4VbLRDWCSYBqffnWqQUee77agKkZTFQ+yEQhPZ7Grl8NepRoGAjxOto0HPL8Q==
 
 serialize-javascript@^1.4.0:
   version "1.5.0"


### PR DESCRIPTION
While upgrading to `dart-sass` the code from seng-scss reported the following:

```
55 │ $maximumFluidTypeViewportWidth: 1440px !global;
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    node_modules/seng-scss/utils/_variables.scss 55:1  @import
    node_modules/seng-scss/base.scss 1:9               @import
    src/app/component/block/two-col/two-col.scss 1:9   root stylesheet
```

This is only apparent on build as on dev build this got suppressed.

Upgrading seng-scss to it's latest version solves this issue.

